### PR TITLE
Skip tests during Gradle build in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN chmod +x ./gradlew && \
 
 # Copiar código fuente y construir el JAR
 COPY src/ ./src/
-RUN ./gradlew build --no-daemon
+RUN ./gradlew build -x test --no-daemon
 
 # Etapa 2: Imagen final
 FROM eclipse-temurin:17-jdk-jammy


### PR DESCRIPTION
Modified the Dockerfile to exclude tests during the Gradle build step using the `-x test` flag. This change accelerates the build process and is suited for environments where running tests isn't necessary at this stage.