### PR TITLE
Enable Liquibase migration and configure database schema management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'org.projectlombok:lombok'
+    implementation 'org.liquibase:liquibase-core'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:postgresql'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,12 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 
-spring.jpa.hibernate.ddl-auto=update
+# Desactivado para que no haya errores con Liquibase
+spring.jpa.hibernate.ddl-auto=none
 
 jwt.secret = mySuperSecretKeyForJWT
 jwt.expirationMs = 3600000
+
+# Liquibase activado
+spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.yaml
+spring.liquibase.enabled=true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: moviesphere-devs
+      changes:
+        - createTable:
+            tableName: users
+            columns:
+              - column:
+                  name: id
+                  type: BIGSERIAL
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: username
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: password
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role
+                  type: VARCHAR(100)


### PR DESCRIPTION
Replaced SQL schema script with a Liquibase changelog for better versioning and migrations. Updated application properties to disable Hibernate's auto-DDL and enable Liquibase. Added Liquibase dependency to the build configuration.